### PR TITLE
Document container runtime hardening steps

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,16 @@ services:
     env_file:
       - .env
     volumes:
-      - dbdata:/data
-    # network_mode: bridge is default; no special ports required
-    # The bot connects outbound to Discord
+      - dbdata:/data:rw
+    deploy:
+      resources:
+        limits:
+          cpus: "0.50"
+          memory: 512M
+        reservations:
+          cpus: "0.25"
+          memory: 256M
 
 volumes:
   dbdata:
     driver: local
-

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+# ensure expected directories exist
+for dir in /app /data; do
+    if [ ! -d "$dir" ]; then
+        mkdir -p "$dir"
+    fi
+done
+
+ensure_dir() {
+    target="$1"
+    expected_mode="$2"
+
+    owner=$(stat -c %U "$target")
+    group=$(stat -c %G "$target")
+    if [ "$owner" != "bot" ] || [ "$group" != "bot" ]; then
+        echo "[entrypoint] $target must be owned by bot:bot but is ${owner}:${group}." >&2
+        echo "[entrypoint] Adjust the host volume ownership before starting the container." >&2
+        exit 1
+    fi
+
+    current_mode=$(stat -c %a "$target")
+    if [ "$current_mode" != "$expected_mode" ]; then
+        chmod "$expected_mode" "$target"
+    fi
+}
+
+ensure_dir /app 750
+ensure_dir /data 700
+
+exec "$@"

--- a/healthcheck.py
+++ b/healthcheck.py
@@ -1,0 +1,27 @@
+"""Container health check for the scheduler bot."""
+import asyncio
+import os
+
+from scheduler_bot.bot import SchedulerBot
+
+
+async def main() -> int:
+    token = os.getenv("DISCORD_TOKEN")
+    if not token:
+        return 1
+
+    bot = SchedulerBot()
+    try:
+        await bot.http.static_login(token.strip())
+        return 0
+    except Exception:
+        return 1
+    finally:
+        try:
+            await bot.http.close()
+        finally:
+            await bot.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))


### PR DESCRIPTION
## Summary
- expand the Container & Runtime section of the security assessment with detailed guidance on user management, filesystem permissions, resource limits, and health checks
- harden the Dockerfile to run as a non-root `bot` user, enforce directory permissions, add an ownership guard entrypoint, and perform a Discord API-based health probe
- configure docker-compose resource reservations and explicit read/write volume semantics

## Testing
- python3 -m compileall src healthcheck.py

------
https://chatgpt.com/codex/tasks/task_e_68cbd27b2a48832cb9bd4fd853d6aa1e