### PR TITLE
Fix health check import path

### DIFF
--- a/healthcheck.py
+++ b/healthcheck.py
@@ -1,6 +1,13 @@
 """Container health check for the scheduler bot."""
 import asyncio
 import os
+import sys
+from pathlib import Path
+
+
+# Ensure the ``src`` directory is importable when the health check runs in
+# isolation (e.g. from Docker health checks) where PYTHONPATH is not set.
+sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))
 
 from scheduler_bot.bot import SchedulerBot
 


### PR DESCRIPTION
## Summary
- ensure the health check script adds the src directory to sys.path before importing project modules

## Testing
- /usr/bin/python3 healthcheck.py *(fails: missing discord.py dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd8aa8cd8832c940aa8383420a9f4