### PR TITLE
Update reminder mentions to only target pending members

### DIFF
--- a/src/scheduler_bot/utils/poll_manager.py
+++ b/src/scheduler_bot/utils/poll_manager.py
@@ -683,9 +683,9 @@ class PollManager:
         # Default to channel reminder
         highlight = None
         allowed_mentions = None
-        if role:
-            highlight = role.mention
-            allowed_mentions = discord.AllowedMentions(roles=True)
+        if pending_members:
+            highlight = " ".join(member.mention for member in pending_members)
+            allowed_mentions = discord.AllowedMentions(users=True, roles=False, everyone=False)
 
         if not manual and role and not pending_members:
             # Avoid sending redundant reminders when everyone with the tracked role responded


### PR DESCRIPTION
## Summary
- update channel reminder mentions to highlight only individual pending members instead of the entire player role
- configure allowed mentions to permit user mentions while suppressing role and @everyone pings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d485e8f244832c86117ce31b14ad03